### PR TITLE
Fix http-adapter version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.6.0",
 
-        "egeloen/http-adapter": "0.8.x-dev",
+        "egeloen/http-adapter": "~0.8.0",
         "jakeasmith/http_build_url": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
We could now use https://github.com/egeloen/ivory-http-adapter/releases/tag/0.8.0
