### PR TITLE
Throw decode exception when Google Http Response is empty (json_decode('') return null)

### DIFF
--- a/src/GoogleGeocodeClient.php
+++ b/src/GoogleGeocodeClient.php
@@ -50,6 +50,12 @@ class GoogleGeocodeClient
             }
 
             $content = (string) $response->getBody();
+            if (empty($content)) {
+                throw new Exception\GoogleGeocodeResponseDecodeException(
+                    'Response is empty, expecting valid json.'
+                );
+            }
+
             $json = json_decode($content, true);
 
             if (null === $json) {

--- a/tests/Units/GoogleGeocodeClient.php
+++ b/tests/Units/GoogleGeocodeClient.php
@@ -94,7 +94,34 @@ class GoogleGeocodeClient extends atoum
             );
     }
 
-    public function test_it_throws_response_decode_exception()
+    public function test_it_throws_response_decode_exception_on_empty_content()
+    {
+        $this
+            ->given(
+                $response = $this->messageFactory->createResponse(
+                    200,
+                    \Ivory\HttpAdapter\Message\RequestInterface::PROTOCOL_VERSION_1_1,
+                    ['Content-Type: application/json'],
+                    ''
+                ),
+                $this->calling($this->mockAdapter)->get = $response,
+                $SUT = new SUT($this->mockAdapter, $this->apiKey)
+            )
+            ->then(
+                $this->exception(function() use($SUT) {
+                    $SUT->executeQuery([]);
+                })
+                ->isInstanceOf('Rezzza\GoogleGeocoder\Exception\GoogleGeocodeResponseDecodeException')
+                ->hasMessage('Response is empty, expecting valid json.')
+            )
+            ->and(
+                $this->mock($this->mockAdapter)
+                    ->call('get')
+                        ->once()
+            );
+    }
+
+    public function test_it_throws_response_decode_exception_on_invalid_json()
     {
         $this
             ->given(


### PR DESCRIPTION
You should test is body is not empty before to use `json_decode`:
https://github.com/rezzza/google-geocoder/blob/c4bcadb0b22d3976ecbd823eab87712950587703/src/GoogleGeocodeClient.php#L44

If not, we will fallback on : 
https://github.com/rezzza/google-geocoder/blob/c4bcadb0b22d3976ecbd823eab87712950587703/src/GoogleGeocodeClient.php#L47
but we have not json error. 
